### PR TITLE
Change object map from O(logN) to O(1)

### DIFF
--- a/src/parser.h
+++ b/src/parser.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <fstream>
 #include <vector>
-#include <map>
+#include <unordered_map>
 
 #include "util/vector/vector.h"
 #include "scene_object.h"
@@ -26,7 +26,7 @@ private:
     Json::Value root;
 
     typedef SceneObject *(Parser::*json_converter)(Json::Value);
-    std::map<std::string, json_converter> converters;
+    std::unordered_map<std::string, json_converter> converters;
 
     bool valid_object_type(std::string type);
 


### PR DESCRIPTION
std::map has O(logN) behavior because it uses a Red-Black
tree. std::unordered_map has O(1) behavior (except in degenerate cases).